### PR TITLE
Failure scenarios enhancement

### DIFF
--- a/build/jar/users.txt
+++ b/build/jar/users.txt
@@ -44,3 +44,8 @@ password=ggoohu
 name=DAMIEN
 password=neimad
 
+name=msisdns
+password=msisdns
+timed.out.msisdns=258024403330,258024403334
+internal.error.msisdns=258024405550,258024405554
+

--- a/com/logica/smscsim/DeliveryInfoSender.java
+++ b/com/logica/smscsim/DeliveryInfoSender.java
@@ -80,6 +80,13 @@ public class DeliveryInfoSender extends ProcessingThread
         submit(processor,submitRequest,messageId,DELIVERED,0);
     }
 
+    public void fail(PDUProcessor processor, SubmitSM submitRequest,
+                     String messageId)
+    {
+        submit(processor,submitRequest,messageId,UNKNOWN,5);
+    }
+
+
     private void deliver(DeliveryInfoEntry entry)
     {
         debug.enter(this,"deliver");

--- a/com/logica/smscsim/PDUProcessor.java
+++ b/com/logica/smscsim/PDUProcessor.java
@@ -66,7 +66,7 @@ public abstract class PDUProcessor
      * Meant to process <code>request</code>s received from client.
      * @param request the request received from client
      */
-    public abstract void clientRequest(Request request);
+    public abstract void clientRequest(Request request) throws InterruptedException;
     
     /**
      * Meant to process <code>response</code>s received from client.

--- a/com/logica/smscsim/Simulator.java
+++ b/com/logica/smscsim/Simulator.java
@@ -165,8 +165,29 @@ public class Simulator
             deliveryInfoSender = new DeliveryInfoSender();
             deliveryInfoSender.start();
             users = new Table(usersFileName);
+
+            com.logica.smscsim.util.Record msisdns = this.users.find(new com.logica.smscsim.util.Attribute("name", "msisdns"));
+            String timedOutMsisdns = null;
+            String internalErrorMsisdns = null;
+
+            if (msisdns != null) {
+                System.out.println("Found msisdns record.");
+                timedOutMsisdns = msisdns.getValue("timed.out.msisdns");
+                internalErrorMsisdns = msisdns.getValue("internal.error.msisdns");
+            } else {
+                System.out.println("Could not find msisnds record.");
+            }
+
+            if (timedOutMsisdns != null) {
+                System.out.println("timedOutMsisds=" + timedOutMsisdns);
+            }
+            if (internalErrorMsisdns != null) {
+                System.out.println("internalErrorMsisds=" + internalErrorMsisdns);
+            }
+
+
             factory = new SimulatorPDUProcessorFactory(processors,messageStore,
-                                                       deliveryInfoSender,users);
+                                                       deliveryInfoSender,users, timedOutMsisdns, internalErrorMsisdns);
 	    factory.setDisplayInfo(displayInfo);
             smscListener.setPDUProcessorFactory(factory);
             smscListener.start();

--- a/com/logica/smscsim/SimulatorPDUProcessorFactory.java
+++ b/com/logica/smscsim/SimulatorPDUProcessorFactory.java
@@ -38,6 +38,8 @@ public class SimulatorPDUProcessorFactory implements PDUProcessorFactory
     private ShortMessageStore messageStore;
     private DeliveryInfoSender deliveryInfoSender;
     private Table users;
+    private String timedOutMsisdnsCsv;
+    private String internalErrorMsisdnsCsv;
 
     /**
      * If the information about processing has to be printed
@@ -57,12 +59,16 @@ public class SimulatorPDUProcessorFactory implements PDUProcessorFactory
     public SimulatorPDUProcessorFactory(PDUProcessorGroup procGroup,
                                         ShortMessageStore messageStore,
                                         DeliveryInfoSender deliveryInfoSender,
-                                        Table users)
+                                        Table users,
+                                        String timedOutMsisdnsCsv,
+                                        String internalErrorMsisdnsCsv)
     {
         this.procGroup = procGroup;
         this.messageStore = messageStore;
         this.deliveryInfoSender = deliveryInfoSender;
         this.users = users;
+        this.timedOutMsisdnsCsv = timedOutMsisdnsCsv;
+        this.internalErrorMsisdnsCsv = internalErrorMsisdnsCsv;
     }
 
     /**
@@ -75,7 +81,7 @@ public class SimulatorPDUProcessorFactory implements PDUProcessorFactory
     public PDUProcessor createPDUProcessor(SMSCSession session)
     {
         SimulatorPDUProcessor simPDUProcessor
-            = new SimulatorPDUProcessor(session,messageStore,users);
+                = new SimulatorPDUProcessor(session,messageStore,users,timedOutMsisdnsCsv,internalErrorMsisdnsCsv);
         simPDUProcessor.setDisplayInfo(getDisplayInfo());
         simPDUProcessor.setGroup(procGroup);
         simPDUProcessor.setDeliveryInfoSender(deliveryInfoSender);


### PR DESCRIPTION
For a number of configurable destination addresses, the simulator should be able to:

- read the configuration attributes once, at startup.
- simulate a response timeout.
- simulate a delivery failure.